### PR TITLE
Rename metainfo xml

### DIFF
--- a/gimp-elsamuko.metainfo.xml
+++ b/gimp-elsamuko.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-	<id>gimp-elsamuko</id>
+	<id>com.github.elsamuko.gimp-elsamuko</id>
 	<extends>org.gimp.GIMP</extends>
 	<name>Elsamuko</name>
 	<summary>Collection of GIMP scripts</summary>


### PR DESCRIPTION
This pull request renamed the metainfo file in adherence to the latest Appstream 1.2 [guideline related to the naming convention](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic).